### PR TITLE
Small backoff process for messages too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2
+* Don't try to flush on each new event when the `numEvents` is not null, this prevents from keep retrying too soon
+when the buffer is too large.
+
 ## 1.3.1
 * Include `regenerateDeviceId` function
 

--- a/lib/src/event_buffer.dart
+++ b/lib/src/event_buffer.dart
@@ -41,7 +41,7 @@ class EventBuffer {
     event.timestamp = TimeUtils().currentTime();
     await store.add(event);
 
-    if (length >= config.bufferSize) {
+    if (length >= config.bufferSize && numEvents == null) {
       await flush();
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplitude_flutter
 description: Official Flutter plugin for tracking events and revenue to Amplitude.
-version: 1.3.1
+version: 1.3.2
 homepage: https://github.com/amplitude/Amplitude-Flutter
 
 environment:


### PR DESCRIPTION
This change will prevent the app from keep retrying too soon when a request received 413 from the API.