### PR TITLE
Instead of discar new events, remove the older ones

### DIFF
--- a/lib/src/event_buffer.dart
+++ b/lib/src/event_buffer.dart
@@ -34,14 +34,14 @@ class EventBuffer {
   /// Adds a raw event hash to the buffer
   Future<void> add(Event event) async {
     if (length >= config.maxStoredEvents) {
-      print('Max stored events reached.  Discarding event.');
-      return;
+      print('Max stored events reached.  Drop first event');
+      await store.drop(1);
     }
 
     event.timestamp = TimeUtils().currentTime();
     await store.add(event);
 
-    if (length >= config.bufferSize && numEvents == null) {
+    if (length >= config.bufferSize) {
       await flush();
     }
   }

--- a/lib/src/event_buffer.dart
+++ b/lib/src/event_buffer.dart
@@ -92,6 +92,8 @@ class EventBuffer {
 
   Future<void> _deleteEvents(List<int> eventIds) async {
     await store.delete(eventIds);
-    numEvents = null;
+    if (numEvents >= length) {
+      numEvents = null;
+    }
   }
 }

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -50,6 +50,16 @@ class Store {
     return _count(db);
   }
 
+  Future<void> drop(int count) async {
+    final db = await _getDb();
+    if (db == null) {
+      return;
+    }
+    final resultCount = await db.rawDelete(
+        'DELETE FROM $EVENTS_TABLE WHERE $COL_ID IN (SELECT T2.$COL_ID FROM $EVENTS_TABLE T2 ORDER BY T2.$COL_ID LIMIT $count)');
+    length -= resultCount;
+  }
+
   Future<void> delete(List<int> eventIds) async {
     final db = await _getDb();
     if (db == null) {


### PR DESCRIPTION
* Remove older events when the buffer is full
* If the amount of events submitted (`numEvents`) are lower than `length` this means the API is throttling (returning 413), so keep using the same `numEvents` until finishing submitting all events. 