### PR TITLE
Bump Android SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Solving this dependency conflict problem

```
Execution failed for task ':amplitude_flutter:checkDebugAndroidTestAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > One or more issues found when checking AAR metadata values:
     Dependency 'androidx.window:window-java:1.0.0-beta04' requires 'compileSdkVersion' to be set to 31 or higher.
     Compilation target for module ':amplitude_flutter' is 'android-29'
     Dependency 'androidx.window:window:1.0.0-beta04' requires 'compileSdkVersion' to be set to 31 or higher.
     Compilation target for module ':amplitude_flutter' is 'android-29'
```